### PR TITLE
[FEAT] 9주차 과제: API 구현

### DIFF
--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionController.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionController.java
@@ -32,11 +32,4 @@ public class MissionController implements MissionControllerDocs {
     ) {
         return ApiResponse.onSuccess(MissionSuccessCode.FOUND, missionService.getMissionByStore(storeId, page));
     }
-
-    @GetMapping("/mission/ongoing")
-    public ApiResponse<MissionResDTO.MissionPreviewListDTO> getMissionByStore(
-            @RequestParam Integer page
-    ) {
-        return ApiResponse.onSuccess(MissionSuccessCode.FOUND, missionService.getMissionOngoing(page));
-    }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionController.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionController.java
@@ -2,7 +2,9 @@ package com.example.umc9th.domain.mission.controller;
 
 import com.example.umc9th.domain.mission.dto.MissionReqDTO;
 import com.example.umc9th.domain.mission.dto.MissionResDTO;
+import com.example.umc9th.domain.mission.entity.Mission;
 import com.example.umc9th.domain.mission.service.MissionService;
+import com.example.umc9th.domain.participation.dto.ParticipationResDTO;
 import com.example.umc9th.global.apipayload.ApiResponse;
 import com.example.umc9th.global.apipayload.exception.code.MissionSuccessCode;
 import jakarta.validation.Valid;

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionController.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionController.java
@@ -16,7 +16,7 @@ public class MissionController {
     private final MissionService missionService;
 
     @PostMapping("/store/{storeId}/mission")
-    public ApiResponse<MissionResDTO.AddDTO> addMission(
+    public ApiResponse<MissionResDTO.MissionPreviewDTO> addMission(
             @RequestBody @Valid MissionReqDTO.AddDTO dto,
             @PathVariable Long storeId
     ) {

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionController.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionController.java
@@ -30,4 +30,11 @@ public class MissionController implements MissionControllerDocs {
     ) {
         return ApiResponse.onSuccess(MissionSuccessCode.FOUND, missionService.getMissionByStore(storeId, page));
     }
+
+    @GetMapping("/mission/ongoing")
+    public ApiResponse<MissionResDTO.MissionPreviewListDTO> getMissionByStore(
+            @RequestParam Integer page
+    ) {
+        return ApiResponse.onSuccess(MissionSuccessCode.FOUND, missionService.getMissionOngoing(page));
+    }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionController.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-public class MissionController {
+public class MissionController implements MissionControllerDocs {
 
     private final MissionService missionService;
 
@@ -21,5 +21,13 @@ public class MissionController {
             @PathVariable Long storeId
     ) {
         return ApiResponse.onSuccess(MissionSuccessCode.FOUND, missionService.addMission(dto, storeId));
+    }
+
+    @GetMapping("/store/{storeId}/mission")
+    public ApiResponse<MissionResDTO.MissionPreviewListDTO> getMissionByStore(
+            @PathVariable Long storeId,
+            @RequestParam Integer page
+    ) {
+        return ApiResponse.onSuccess(MissionSuccessCode.FOUND, missionService.getMissionByStore(storeId, page));
     }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionControllerDocs.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionControllerDocs.java
@@ -21,16 +21,4 @@ public interface MissionControllerDocs {
             @PathVariable Long storeId,
             @RequestParam Integer page
     );
-
-    @Operation(
-            summary = "진행 중 미션 목록 조회 API",
-            description = "진행 중인 미션을 조회합니다. 페이지네이션으로 제공합니다."
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
-    })
-    ApiResponse<MissionResDTO.MissionPreviewListDTO> getMissionByStore(
-            @RequestParam Integer page
-    );
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionControllerDocs.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionControllerDocs.java
@@ -21,4 +21,16 @@ public interface MissionControllerDocs {
             @PathVariable Long storeId,
             @RequestParam Integer page
     );
+
+    @Operation(
+            summary = "진행 중 미션 목록 조회 API",
+            description = "진행 중인 미션을 조회합니다. 페이지네이션으로 제공합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
+    })
+    ApiResponse<MissionResDTO.MissionPreviewListDTO> getMissionByStore(
+            @RequestParam Integer page
+    );
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionControllerDocs.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/controller/MissionControllerDocs.java
@@ -1,0 +1,24 @@
+package com.example.umc9th.domain.mission.controller;
+
+import com.example.umc9th.domain.mission.dto.MissionResDTO;
+import com.example.umc9th.global.apipayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface MissionControllerDocs {
+
+    @Operation(
+            summary = "가게의 미션 목록 조회 API",
+            description = "특정 가게의 미션을 조회합니다. 페이지네이션으로 제공합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
+    })
+    ApiResponse<MissionResDTO.MissionPreviewListDTO> getMissionByStore(
+            @PathVariable Long storeId,
+            @RequestParam Integer page
+    );
+}

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/converter/MissionConverter.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/converter/MissionConverter.java
@@ -23,8 +23,8 @@ public class MissionConverter {
                 .build();
     }
 
-    public static MissionResDTO.AddDTO toAddDTO(Mission mission) {
-        return MissionResDTO.AddDTO.builder()
+    public static MissionResDTO.MissionPreviewDTO toPreviewDTO(Mission mission) {
+        return MissionResDTO.MissionPreviewDTO.builder()
                 .id(mission.getId())
                 .rewardType(mission.getRewardType().toString())
                 .rewardValue(mission.getRewardValue())

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/converter/MissionConverter.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/converter/MissionConverter.java
@@ -3,8 +3,10 @@ package com.example.umc9th.domain.mission.converter;
 import com.example.umc9th.domain.mission.dto.MissionReqDTO;
 import com.example.umc9th.domain.mission.dto.MissionResDTO;
 import com.example.umc9th.domain.mission.entity.Mission;
+import com.example.umc9th.domain.review.entity.Review;
 import com.example.umc9th.domain.store.entity.Store;
 import com.example.umc9th.domain.mission.enums.RewardType;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
 
@@ -34,6 +36,19 @@ public class MissionConverter {
                 .validFrom(mission.getValidFrom().toString())
                 .validTo(mission.getValidTo().toString())
                 .storeId(mission.getStore().getId())
+                .build();
+    }
+
+    public static MissionResDTO.MissionPreviewListDTO toMissionPreviewList(Page<Mission> result) {
+        return MissionResDTO.MissionPreviewListDTO.builder()
+                .missionList(result.getContent().stream()
+                        .map(MissionConverter::toPreviewDTO)
+                        .toList())
+                .listSize(result.getSize())
+                .totalPage(result.getTotalPages())
+                .totalElements(result.getTotalElements())
+                .isFirst(result.isFirst())
+                .isLast(result.isLast())
                 .build();
     }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/dto/MissionResDTO.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/dto/MissionResDTO.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 public class MissionResDTO {
 
     @Builder
-    public record AddDTO (
+    public record MissionPreviewDTO (
             Long id,
             String rewardType,
             Long rewardValue,

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/dto/MissionResDTO.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/dto/MissionResDTO.java
@@ -2,6 +2,8 @@ package com.example.umc9th.domain.mission.dto;
 
 import lombok.Builder;
 
+import java.util.List;
+
 public class MissionResDTO {
 
     @Builder
@@ -16,4 +18,14 @@ public class MissionResDTO {
             String validTo,
             Long storeId
     ) {}
+
+    @Builder
+    public record MissionPreviewListDTO(
+            List<MissionResDTO.MissionPreviewDTO> missionList,
+            Integer listSize,
+            Integer totalPage,
+            Long totalElements,
+            Boolean isFirst,
+            Boolean isLast
+    ){}
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/repository/MissionRepository.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/repository/MissionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/repository/MissionRepository.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/repository/MissionRepository.java
@@ -2,7 +2,9 @@ package com.example.umc9th.domain.mission.repository;
 
 import com.example.umc9th.domain.common.entity.Dong;
 import com.example.umc9th.domain.mission.entity.Mission;
+import com.example.umc9th.domain.store.entity.Store;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -32,4 +34,5 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     """)
     Optional<Mission> findValidActiveMission(@Param("id") Long id, @Param("now") LocalDate now);
 
+    Page<Mission> findAllByStore(Store store, PageRequest pageRequest);
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/repository/MissionRepository.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/repository/MissionRepository.java
@@ -36,11 +36,4 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     Optional<Mission> findValidActiveMissionByMemberId(@Param("id") Long id, @Param("now") LocalDate now);
 
     Page<Mission> findAllByStore(Store store, PageRequest pageRequest);
-
-    @Query("""
-        SELECT m FROM Mission m
-        WHERE m.isActive = true
-        AND :now BETWEEN m.validFrom AND m.validTo
-    """)
-    Page<Mission> findValidActiveMission(PageRequest pageRequest, @Param("now") LocalDate now);
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/repository/MissionRepository.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/repository/MissionRepository.java
@@ -32,7 +32,14 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
         AND m.isActive = true
         AND :now BETWEEN m.validFrom AND m.validTo
     """)
-    Optional<Mission> findValidActiveMission(@Param("id") Long id, @Param("now") LocalDate now);
+    Optional<Mission> findValidActiveMissionByMemberId(@Param("id") Long id, @Param("now") LocalDate now);
 
     Page<Mission> findAllByStore(Store store, PageRequest pageRequest);
+
+    @Query("""
+        SELECT m FROM Mission m
+        WHERE m.isActive = true
+        AND :now BETWEEN m.validFrom AND m.validTo
+    """)
+    Page<Mission> findValidActiveMission(PageRequest pageRequest, @Param("now") LocalDate now);
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
@@ -1,5 +1,7 @@
 package com.example.umc9th.domain.mission.service;
 
+import com.example.umc9th.domain.member.entity.Member;
+import com.example.umc9th.domain.member.repository.MemberRepository;
 import com.example.umc9th.domain.mission.converter.MissionConverter;
 import com.example.umc9th.domain.mission.dto.MissionReqDTO;
 import com.example.umc9th.domain.mission.dto.MissionResDTO;
@@ -7,7 +9,9 @@ import com.example.umc9th.domain.mission.entity.Mission;
 import com.example.umc9th.domain.mission.repository.MissionRepository;
 import com.example.umc9th.domain.store.entity.Store;
 import com.example.umc9th.domain.store.repository.StoreRepository;
+import com.example.umc9th.global.apipayload.exception.MemberException;
 import com.example.umc9th.global.apipayload.exception.StoreException;
+import com.example.umc9th.global.apipayload.exception.code.MemberErrorCode;
 import com.example.umc9th.global.apipayload.exception.code.StoreErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,6 +26,7 @@ public class MissionService {
 
     private final StoreRepository storeRepository;
     private final MissionRepository missionRepository;
+    private final MemberRepository memberRepository;
 
     public MissionResDTO.MissionPreviewDTO addMission(MissionReqDTO.AddDTO dto, Long storeId) {
         // 가게 조회

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
@@ -1,13 +1,10 @@
 package com.example.umc9th.domain.mission.service;
 
-import com.example.umc9th.domain.member.entity.Member;
 import com.example.umc9th.domain.mission.converter.MissionConverter;
 import com.example.umc9th.domain.mission.dto.MissionReqDTO;
 import com.example.umc9th.domain.mission.dto.MissionResDTO;
 import com.example.umc9th.domain.mission.entity.Mission;
 import com.example.umc9th.domain.mission.repository.MissionRepository;
-import com.example.umc9th.domain.review.converter.ReviewConverter;
-import com.example.umc9th.domain.review.entity.Review;
 import com.example.umc9th.domain.store.entity.Store;
 import com.example.umc9th.domain.store.repository.StoreRepository;
 import com.example.umc9th.global.apipayload.exception.StoreException;
@@ -16,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +40,13 @@ public class MissionService {
 
         PageRequest pageRequest = PageRequest.of(page, 10);
         Page<Mission> result = missionRepository.findAllByStore(store, pageRequest);
+
+        return MissionConverter.toMissionPreviewList(result);
+    }
+
+    public MissionResDTO.MissionPreviewListDTO getMissionOngoing(Integer page) {
+        PageRequest pageRequest = PageRequest.of(page, 10);
+        Page<Mission> result = missionRepository.findValidActiveMission(pageRequest, LocalDate.now());
 
         return MissionConverter.toMissionPreviewList(result);
     }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
@@ -48,11 +48,4 @@ public class MissionService {
 
         return MissionConverter.toMissionPreviewList(result);
     }
-
-    public MissionResDTO.MissionPreviewListDTO getMissionOngoing(Integer page) {
-        PageRequest pageRequest = PageRequest.of(page, 10);
-        Page<Mission> result = missionRepository.findValidActiveMission(pageRequest, LocalDate.now());
-
-        return MissionConverter.toMissionPreviewList(result);
-    }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
@@ -19,7 +19,7 @@ public class MissionService {
     private final StoreRepository storeRepository;
     private final MissionRepository missionRepository;
 
-    public MissionResDTO.AddDTO addMission(MissionReqDTO.AddDTO dto, Long storeId) {
+    public MissionResDTO.MissionPreviewDTO addMission(MissionReqDTO.AddDTO dto, Long storeId) {
         // 가게 조회
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
@@ -27,6 +27,6 @@ public class MissionService {
         Mission mission = MissionConverter.toMission(dto, store);
         missionRepository.save(mission);
 
-        return MissionConverter.toAddDTO(mission);
+        return MissionConverter.toPreviewDTO(mission);
     }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/mission/service/MissionService.java
@@ -1,15 +1,20 @@
 package com.example.umc9th.domain.mission.service;
 
+import com.example.umc9th.domain.member.entity.Member;
 import com.example.umc9th.domain.mission.converter.MissionConverter;
 import com.example.umc9th.domain.mission.dto.MissionReqDTO;
 import com.example.umc9th.domain.mission.dto.MissionResDTO;
 import com.example.umc9th.domain.mission.entity.Mission;
 import com.example.umc9th.domain.mission.repository.MissionRepository;
+import com.example.umc9th.domain.review.converter.ReviewConverter;
+import com.example.umc9th.domain.review.entity.Review;
 import com.example.umc9th.domain.store.entity.Store;
 import com.example.umc9th.domain.store.repository.StoreRepository;
 import com.example.umc9th.global.apipayload.exception.StoreException;
 import com.example.umc9th.global.apipayload.exception.code.StoreErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -28,5 +33,15 @@ public class MissionService {
         missionRepository.save(mission);
 
         return MissionConverter.toPreviewDTO(mission);
+    }
+
+    public MissionResDTO.MissionPreviewListDTO getMissionByStore(Long storeId, Integer page) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
+
+        PageRequest pageRequest = PageRequest.of(page, 10);
+        Page<Mission> result = missionRepository.findAllByStore(store, pageRequest);
+
+        return MissionConverter.toMissionPreviewList(result);
     }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/participation/controller/ParticipationController.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/participation/controller/ParticipationController.java
@@ -1,8 +1,10 @@
 package com.example.umc9th.domain.participation.controller;
 
+import com.example.umc9th.domain.mission.dto.MissionResDTO;
 import com.example.umc9th.domain.participation.dto.ParticipationResDTO;
 import com.example.umc9th.domain.participation.service.ParticipationService;
 import com.example.umc9th.global.apipayload.ApiResponse;
+import com.example.umc9th.global.apipayload.exception.code.MissionSuccessCode;
 import com.example.umc9th.global.apipayload.exception.code.ParticipationSuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -15,10 +17,18 @@ public class ParticipationController {
     private final ParticipationService participationService;
 
     @PostMapping("/{missionId}/participate")
-    public ApiResponse<ParticipationResDTO.AddDTO> addParticipation(
+    public ApiResponse<ParticipationResDTO.PreviewDTO> addParticipation(
             @RequestHeader("X-USER-ID") Long memberId, // 임시: 실제 인증 방식과 연동 예정
             @PathVariable Long missionId
     ) {
         return ApiResponse.onSuccess(ParticipationSuccessCode.FOUND, participationService.addParticipation(memberId, missionId));
+    }
+
+    @PatchMapping("/mission/{missionId}/complete")
+    public ApiResponse<ParticipationResDTO.PreviewDTO> completeMission(
+            @RequestHeader("X-USER-ID") Long memberId, // 임시 헤더로 받기
+            @PathVariable Long missionId
+    ) {
+        return ApiResponse.onSuccess(MissionSuccessCode.FOUND, participationService.completeParticipation(memberId, missionId));
     }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/participation/controller/ParticipationController.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/participation/controller/ParticipationController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/missions")
-public class ParticipationController {
+public class ParticipationController implements ParticipationControllerDocs{
 
     private final ParticipationService participationService;
 
@@ -22,6 +22,14 @@ public class ParticipationController {
             @PathVariable Long missionId
     ) {
         return ApiResponse.onSuccess(ParticipationSuccessCode.FOUND, participationService.addParticipation(memberId, missionId));
+    }
+
+    @GetMapping("/participation/ongoing")
+    public ApiResponse<MissionResDTO.MissionPreviewListDTO> getOngoingParticipation(
+            @RequestHeader("X-USER-ID") Long memberId, // 임시: 실제 인증 방식과 연동 예정
+            @RequestParam Integer page
+    ) {
+        return ApiResponse.onSuccess(MissionSuccessCode.FOUND, participationService.getOngoingParticipation(memberId, page));
     }
 
     @PatchMapping("/mission/{missionId}/complete")

--- a/umc9th/src/main/java/com/example/umc9th/domain/participation/controller/ParticipationControllerDocs.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/participation/controller/ParticipationControllerDocs.java
@@ -1,37 +1,39 @@
-package com.example.umc9th.domain.review.controller;
+package com.example.umc9th.domain.participation.controller;
 
-import com.example.umc9th.domain.review.dto.ReviewResDTO;
+import com.example.umc9th.domain.mission.dto.MissionResDTO;
+import com.example.umc9th.domain.participation.dto.ParticipationResDTO;
 import com.example.umc9th.global.apipayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
-public interface ReviewControllerDocs {
+public interface ParticipationControllerDocs {
 
     @Operation(
-            summary = "가게의 리뷰 목록 조회 API By 지요",
-            description = "특정 가게의 리뷰를 모두 조회합니다. 페이지네이션으로 제공합니다."
+            summary = "내가 진행 중인 미션 목록 조회 API",
+            description = "내가 진행 중인 미션을 조회합니다. 페이지네이션으로 제공합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
     })
-    ApiResponse<ReviewResDTO.ReviewPreViewListDTO> getReviews(
-            @RequestParam String storeName,
+    ApiResponse<MissionResDTO.MissionPreviewListDTO> getOngoingParticipation(
+            @RequestHeader("X-USER-ID") Long memberId,
             @RequestParam Integer page
     );
 
     @Operation(
-            summary = "내가 작성한 리뷰 목록 조회 API",
-            description = "내가 작성한 리뷰의 목록을 조회합니다. 페이지네이션으로 제공합니다."
+            summary = "진행 중인 미션 완료 처리 API",
+            description = "내가 진행 중인 미션을 완료 처리합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
     })
-    ApiResponse<ReviewResDTO.ReviewPreViewListDTO> getMyReviews(
+    ApiResponse<ParticipationResDTO.PreviewDTO> completeMission(
             @RequestHeader("X-USER-ID") Long memberId, // 임시 헤더로 받기
-            @RequestParam Integer page
+            @PathVariable Long missionId
     );
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/participation/converter/ParticipationConverter.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/participation/converter/ParticipationConverter.java
@@ -16,8 +16,8 @@ public class ParticipationConverter {
                 .build();
     }
 
-    public static ParticipationResDTO.AddDTO toAddDTO(Participation participation) {
-        return ParticipationResDTO.AddDTO.builder()
+    public static ParticipationResDTO.PreviewDTO toPreviewDTO(Participation participation) {
+        return ParticipationResDTO.PreviewDTO.builder()
                 .id(participation.getId())
                 .memberId(participation.getMember().getId())
                 .participateStatus(participation.getStatus().name())

--- a/umc9th/src/main/java/com/example/umc9th/domain/participation/dto/ParticipationResDTO.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/participation/dto/ParticipationResDTO.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 public class ParticipationResDTO {
 
     @Builder
-    public record AddDTO(
+    public record PreviewDTO(
             Long id,
             Long memberId,
             String participateStatus,

--- a/umc9th/src/main/java/com/example/umc9th/domain/participation/entity/Participation.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/participation/entity/Participation.java
@@ -35,4 +35,9 @@ public class Participation extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_id", nullable = false)
     private Mission mission;
+
+    public void complete(LocalDate completedAt) {
+        this.completedAt = completedAt;
+        this.status = ParticipateStatus.COMPLETED;
+    }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/participation/repository/ParticipationRepository.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/participation/repository/ParticipationRepository.java
@@ -1,6 +1,7 @@
 package com.example.umc9th.domain.participation.repository;
 
 import com.example.umc9th.domain.member.entity.Member;
+import com.example.umc9th.domain.mission.entity.Mission;
 import com.example.umc9th.domain.participation.entity.Participation;
 import com.example.umc9th.domain.participation.enums.ParticipateStatus;
 import org.springframework.data.domain.Page;
@@ -11,4 +12,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     // 진행 중, 진행 완료한 미션 모아서 보는 쿼리 (페이징 포함)
     Page<Participation> findByMemberAndStatus(Member member, ParticipateStatus status, Pageable pageable);
+
+    Participation findByMemberAndMission(Member member, Mission mission);
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/participation/repository/ParticipationRepository.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/participation/repository/ParticipationRepository.java
@@ -7,11 +7,20 @@ import com.example.umc9th.domain.participation.enums.ParticipateStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
 
     // 진행 중, 진행 완료한 미션 모아서 보는 쿼리 (페이징 포함)
     Page<Participation> findByMemberAndStatus(Member member, ParticipateStatus status, Pageable pageable);
+
+    @Query("""
+        SELECT p FROM Participation p
+        JOIN FETCH p.mission
+        WHERE p.member = :member AND p.status = 'ONGOING'
+    """)
+    Page<Participation> findOngoingParticipation(@Param("member") Member member, Pageable pageRequest);
 
     Participation findByMemberAndMission(Member member, Mission mission);
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/participation/service/ParticipationService.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/participation/service/ParticipationService.java
@@ -25,7 +25,7 @@ public class ParticipationService {
     private final MissionRepository missionRepository;
     private final ParticipationRepository participationRepository;
 
-    public ParticipationResDTO.AddDTO addParticipation(Long memberId, Long missionId) {
+    public ParticipationResDTO.PreviewDTO addParticipation(Long memberId, Long missionId) {
         // 사용자 조회
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
@@ -37,6 +37,19 @@ public class ParticipationService {
         Participation participation = ParticipationConverter.toParticipation(member, mission);
         participationRepository.save(participation);
 
-        return ParticipationConverter.toAddDTO(participation);
+        return ParticipationConverter.toPreviewDTO(participation);
+    }
+
+    public ParticipationResDTO.PreviewDTO completeParticipation(Long memberId, Long missionId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        Mission mission = missionRepository.findById(missionId)
+                        .orElseThrow(() -> new MissionException(MissionErrorCode.NOT_FOUND));
+
+        Participation participation = participationRepository.findByMemberAndMission(member, mission);
+        participation.complete(LocalDate.now());
+
+        return ParticipationConverter.toPreviewDTO(participation);
     }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/participation/service/ParticipationService.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/participation/service/ParticipationService.java
@@ -31,7 +31,7 @@ public class ParticipationService {
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
         // 미션 조회
-        Mission mission = missionRepository.findValidActiveMission(missionId, LocalDate.now())
+        Mission mission = missionRepository.findValidActiveMissionByMemberId(missionId, LocalDate.now())
                 .orElseThrow(() -> new MissionException(MissionErrorCode.NOT_FOUND));
 
         Participation participation = ParticipationConverter.toParticipation(member, mission);

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/controller/ReviewController.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.example.umc9th.domain.review.dto.ReviewResDTO;
 import com.example.umc9th.domain.review.service.ReviewQueryService;
 import com.example.umc9th.global.apipayload.ApiResponse;
 import com.example.umc9th.global.apipayload.exception.code.ReviewSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -17,13 +18,13 @@ public class ReviewController implements ReviewControllerDocs {
 
     private final ReviewQueryService reviewService;
 
-    @GetMapping("/reviews/my")
-    public ApiResponse<List<ReviewResDTO.GetMyDTO>> getMyReviews(
+    @GetMapping("/reviews/detail")
+    public ApiResponse<List<ReviewResDTO.GetMyDTO>> getReviewsByDetailFilter(
             @RequestHeader("X-USER-ID") Long memberId, // 임시 헤더로 받기
             @RequestParam(required = false) String storeName,  // 가게 이름 필터
             @RequestParam(required = false) Integer ratingGroup   // 별점 필터
     ) {
-        return ApiResponse.onSuccess(ReviewSuccessCode.FOUND, reviewService.getMyReviews(memberId, storeName, ratingGroup));
+        return ApiResponse.onSuccess(ReviewSuccessCode.FOUND, reviewService.getReviewsByDetailFilter(memberId, storeName, ratingGroup));
     }
 
     @PostMapping("/store/{storeId}/reviews")

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/controller/ReviewController.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/controller/ReviewController.java
@@ -45,4 +45,17 @@ public class ReviewController implements ReviewControllerDocs {
         ReviewSuccessCode code = ReviewSuccessCode.FOUND;
         return ApiResponse.onSuccess(code, reviewService.findReview(storeName, page));
     }
+
+    // 내가 작성한 리뷰 목록 조회
+    @Operation(
+            summary = "내가 작성한 리뷰 목록 조회 API",
+            description = "내가 작성한 리뷰의 목록을 조회합니다. 페이지네이션으로 제공합니다."
+    )
+    @GetMapping("/reviews/my")
+    public ApiResponse<ReviewResDTO.ReviewPreViewListDTO> getMyReviews(
+            @RequestHeader("X-USER-ID") Long memberId, // 임시 헤더로 받기
+            @RequestParam Integer page
+    ) {
+        return ApiResponse.onSuccess(ReviewSuccessCode.FOUND, reviewService.getMyReviews(memberId, page));
+    }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/controller/ReviewController.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/controller/ReviewController.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-public class ReviewController {
+public class ReviewController implements ReviewControllerDocs {
 
     private final ReviewQueryService reviewService;
 
@@ -33,5 +33,15 @@ public class ReviewController {
             @PathVariable Long storeId
     ) {
         return ApiResponse.onSuccess(ReviewSuccessCode.FOUND, reviewService.addReview(memberId, dto, storeId));
+    }
+
+    // 가게의 리뷰 목록 조회
+    @GetMapping("/reviews")
+    public ApiResponse<ReviewResDTO.ReviewPreViewListDTO> getReviews(
+            @RequestParam String storeName,
+            @RequestParam Integer page
+    ) {
+        ReviewSuccessCode code = ReviewSuccessCode.FOUND;
+        return ApiResponse.onSuccess(code, reviewService.findReview(storeName, page));
     }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/controller/ReviewControllerDocs.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/controller/ReviewControllerDocs.java
@@ -4,6 +4,8 @@ import com.example.umc9th.domain.review.dto.ReviewResDTO;
 import com.example.umc9th.global.apipayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 public interface ReviewControllerDocs {
@@ -18,6 +20,19 @@ public interface ReviewControllerDocs {
     })
     ApiResponse<ReviewResDTO.ReviewPreViewListDTO> getReviews(
             @RequestParam String storeName,
+            @RequestParam Integer page
+    );
+
+    @Operation(
+            summary = "내가 작성한 리뷰 목록 조회 API",
+            description = "내가 작성한 리뷰의 목록을 조회합니다. 페이지네이션으로 제공합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
+    })
+    ApiResponse<ReviewResDTO.ReviewPreViewListDTO> getMyReviews(
+            @RequestHeader("X-USER-ID") Long memberId, // 임시 헤더로 받기
             @RequestParam Integer page
     );
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/controller/ReviewControllerDocs.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/controller/ReviewControllerDocs.java
@@ -1,0 +1,23 @@
+package com.example.umc9th.domain.review.controller;
+
+import com.example.umc9th.domain.review.dto.ReviewResDTO;
+import com.example.umc9th.global.apipayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface ReviewControllerDocs {
+
+    @Operation(
+            summary = "가게의 리뷰 목록 조회 API By 지요",
+            description = "특정 가게의 리뷰를 모두 조회합니다. 페이지네이션으로 제공합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
+    })
+    ApiResponse<ReviewResDTO.ReviewPreViewListDTO> getReviews(
+            @RequestParam String storeName,
+            @RequestParam Integer page
+    );
+}

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/converter/ReviewConverter.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/converter/ReviewConverter.java
@@ -6,7 +6,9 @@ import com.example.umc9th.domain.review.dto.ReviewResDTO;
 import com.example.umc9th.domain.review.entity.Review;
 import com.example.umc9th.domain.review.entity.ReviewImage;
 import com.example.umc9th.domain.store.entity.Store;
+import org.springframework.data.domain.Page;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.stream.Collectors;
 
@@ -49,6 +51,31 @@ public class ReviewConverter {
                 .imageUrls(review.getImages().stream()
                         .map(image -> image.getImageUrl())
                         .collect(Collectors.toList()))
+                .build();
+    }
+
+    public static ReviewResDTO.ReviewPreViewListDTO toReviewPreviewListDTO(
+            Page<Review> result
+    ) {
+        return ReviewResDTO.ReviewPreViewListDTO.builder()
+                .reviewList(result.getContent().stream()
+                        .map(ReviewConverter::toReviewPreviewDTO)
+                        .toList()
+                )
+                .listSize(result.getSize())
+                .totalPage(result.getTotalPages())
+                .totalElements(result.getTotalElements())
+                .isFirst(result.isFirst())
+                .isLast(result.isLast())
+                .build();
+    }
+
+    public static ReviewResDTO.ReviewPreViewDTO toReviewPreviewDTO(Review review) {
+        return ReviewResDTO.ReviewPreViewDTO.builder()
+                .ownerNickname(review.getMember().getName())
+                .score(review.getRating().floatValue())
+                .body(review.getContent())
+                .createdAt(LocalDate.from(review.getCreatedAt()))
                 .build();
     }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/dto/ReviewResDTO.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/dto/ReviewResDTO.java
@@ -2,6 +2,7 @@ package com.example.umc9th.domain.review.dto;
 
 import lombok.Builder;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class ReviewResDTO {
@@ -51,4 +52,22 @@ public class ReviewResDTO {
             String content,
             List<String> imageUrls
     ) {}
+
+    @Builder
+    public record ReviewPreViewListDTO(
+            List<ReviewPreViewDTO> reviewList,
+            Integer listSize,
+            Integer totalPage,
+            Long totalElements,
+            Boolean isFirst,
+            Boolean isLast
+    ){}
+
+    @Builder
+    public record ReviewPreViewDTO(
+            String ownerNickname,
+            Float score,
+            String body,
+            LocalDate createdAt
+    ){}
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/exception/ReviewException.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/exception/ReviewException.java
@@ -1,0 +1,10 @@
+package com.example.umc9th.domain.review.exception;
+
+import com.example.umc9th.global.apipayload.code.BaseErrorCode;
+import com.example.umc9th.global.apipayload.exception.GeneralException;
+
+public class ReviewException extends GeneralException {
+    public ReviewException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/exception/code/ReviewErrorCode.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/exception/code/ReviewErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.umc9th.domain.review.exception.code;
+
+import com.example.umc9th.global.apipayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewErrorCode implements BaseErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND,
+            "REVIEW404_1",
+            "해당 리뷰를 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/exception/code/ReviewSuccessCode.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/exception/code/ReviewSuccessCode.java
@@ -1,0 +1,20 @@
+package com.example.umc9th.domain.review.exception.code;
+
+import com.example.umc9th.global.apipayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewSuccessCode implements BaseSuccessCode {
+
+    FOUND(HttpStatus.FOUND,
+            "REVIEW200_1",
+            "리뷰를 성공적으로 조회했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepository.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.example.umc9th.domain.review.repository;
 
+import com.example.umc9th.domain.member.entity.Member;
 import com.example.umc9th.domain.review.entity.Review;
 import com.example.umc9th.domain.store.entity.Store;
 import org.springframework.data.domain.Page;
@@ -10,8 +11,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQueryDsl {
     Page<Review> findAllByStore(Store store, PageRequest pageRequest);
-
+    Page<Review> findAllByMember(Member member, PageRequest pageRequest);
 //    void save(Review review);
-
-
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepository.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepository.java
@@ -1,11 +1,15 @@
 package com.example.umc9th.domain.review.repository;
 
 import com.example.umc9th.domain.review.entity.Review;
+import com.example.umc9th.domain.store.entity.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQueryDsl {
+    Page<Review> findAllByStore(Store store, PageRequest pageRequest);
 
 //    void save(Review review);
 

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryService.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface ReviewQueryService {
 
-    List<ReviewResDTO.GetMyDTO> getMyReviews(Long userId, String storeName, Integer ratingGroup);
+    List<ReviewResDTO.GetMyDTO> getReviewsByDetailFilter(Long userId, String storeName, Integer ratingGroup);
     ReviewResDTO.AddDTO addReview(Long memberId, ReviewReqDTO.AddDTO dto, Long storeId);
     // 검색 API
 //    List<Review> searchReview(String filter, String type) throws Exception;

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryService.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryService.java
@@ -12,4 +12,5 @@ public interface ReviewQueryService {
     // 검색 API
 //    List<Review> searchReview(String filter, String type) throws Exception;
     ReviewResDTO.ReviewPreViewListDTO findReview(String storeName, Integer page);
+    ReviewResDTO.ReviewPreViewListDTO getMyReviews(Long userId, Integer page);
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryService.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryService.java
@@ -1,59 +1,15 @@
 package com.example.umc9th.domain.review.service;
 
-import com.example.umc9th.domain.member.entity.Member;
-import com.example.umc9th.domain.member.repository.MemberRepository;
-import com.example.umc9th.domain.review.converter.ReviewConverter;
 import com.example.umc9th.domain.review.dto.ReviewReqDTO;
 import com.example.umc9th.domain.review.dto.ReviewResDTO;
-import com.example.umc9th.domain.review.entity.QReview;
-import com.example.umc9th.domain.review.entity.Review;
-import com.example.umc9th.domain.review.repository.ReviewRepository;
-import com.example.umc9th.domain.store.entity.Store;
-import com.example.umc9th.domain.store.repository.StoreRepository;
-import com.example.umc9th.global.apipayload.exception.StoreException;
-import com.example.umc9th.global.apipayload.exception.code.StoreErrorCode;
-import com.querydsl.core.BooleanBuilder;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Service
-@RequiredArgsConstructor
-public class ReviewQueryService {
+public interface ReviewQueryService {
 
-    private final MemberRepository memberRepository;
-    private final ReviewRepository reviewRepository;
-    private final StoreRepository storeRepository;
-
-    public List<ReviewResDTO.GetMyDTO> getMyReviews(Long userId, String storeName, Integer ratingGroup) {
-        QReview review = QReview.review;
-        BooleanBuilder builder = new BooleanBuilder();
-
-        if (storeName != null) {
-            builder.and(review.store.name.eq(storeName));
-        }
-        if (ratingGroup != null) {
-            double lowerBound = ratingGroup;
-            double upperBound = Math.min(ratingGroup + 0.9, 5.0);
-
-            builder.and(review.rating.between(lowerBound, upperBound));
-        }
-
-        return reviewRepository.findMyReviewsByFilter(userId, builder);
-    }
-
-    public ReviewResDTO.AddDTO addReview(Long memberId, ReviewReqDTO.AddDTO dto, Long storeId) {
-        // 사용자 조회
-        Member member = memberRepository.findMemberById(memberId);
-
-        // 가게 조회
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
-
-        Review review = ReviewConverter.toReview(dto, member, store);
-        reviewRepository.save(review);
-
-        return ReviewConverter.toAddDTO(review);
-    }
+    List<ReviewResDTO.GetMyDTO> getMyReviews(Long userId, String storeName, Integer ratingGroup);
+    ReviewResDTO.AddDTO addReview(Long memberId, ReviewReqDTO.AddDTO dto, Long storeId);
+    // 검색 API
+//    List<Review> searchReview(String filter, String type) throws Exception;
+    ReviewResDTO.ReviewPreViewListDTO findReview(String storeName, Integer page);
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryServiceImpl.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryServiceImpl.java
@@ -1,0 +1,74 @@
+package com.example.umc9th.domain.review.service;
+
+import com.example.umc9th.domain.member.entity.Member;
+import com.example.umc9th.domain.member.repository.MemberRepository;
+import com.example.umc9th.domain.review.converter.ReviewConverter;
+import com.example.umc9th.domain.review.dto.ReviewReqDTO;
+import com.example.umc9th.domain.review.dto.ReviewResDTO;
+import com.example.umc9th.domain.review.entity.QReview;
+import com.example.umc9th.domain.review.entity.Review;
+import com.example.umc9th.domain.review.repository.ReviewRepository;
+import com.example.umc9th.domain.store.entity.Store;
+import com.example.umc9th.domain.store.repository.StoreRepository;
+import com.example.umc9th.global.apipayload.exception.StoreException;
+import com.example.umc9th.global.apipayload.exception.code.StoreErrorCode;
+import com.querydsl.core.BooleanBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryServiceImpl implements ReviewQueryService {
+
+    private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
+    private final StoreRepository storeRepository;
+
+    @Override
+    public List<ReviewResDTO.GetMyDTO> getMyReviews(Long userId, String storeName, Integer ratingGroup) {
+        QReview review = QReview.review;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (storeName != null) {
+            builder.and(review.store.name.eq(storeName));
+        }
+        if (ratingGroup != null) {
+            double lowerBound = ratingGroup;
+            double upperBound = Math.min(ratingGroup + 0.9, 5.0);
+
+            builder.and(review.rating.between(lowerBound, upperBound));
+        }
+
+        return reviewRepository.findMyReviewsByFilter(userId, builder);
+    }
+
+    @Override
+    public ReviewResDTO.AddDTO addReview(Long memberId, ReviewReqDTO.AddDTO dto, Long storeId) {
+        // 사용자 조회
+        Member member = memberRepository.findMemberById(memberId);
+
+        // 가게 조회
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
+
+        Review review = ReviewConverter.toReview(dto, member, store);
+        reviewRepository.save(review);
+
+        return ReviewConverter.toAddDTO(review);
+    }
+
+    @Override
+    public ReviewResDTO.ReviewPreViewListDTO findReview(String storeName, Integer page) {
+        Store store = storeRepository.findByName(storeName)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
+
+        PageRequest pageRequest = PageRequest.of(page, 5);
+        Page<Review> result = reviewRepository.findAllByStore(store, pageRequest);
+
+        return ReviewConverter.toReviewPreviewListDTO(result);
+    }
+}

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryServiceImpl.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryServiceImpl.java
@@ -71,4 +71,14 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 
         return ReviewConverter.toReviewPreviewListDTO(result);
     }
+
+    @Override
+    public ReviewResDTO.ReviewPreViewListDTO getMyReviews(Long userId, Integer page) {
+        Member member = memberRepository.findMemberById(userId);
+
+        PageRequest pageRequest = PageRequest.of(page, 5);
+        Page<Review> result = reviewRepository.findAllByMember(member, pageRequest);
+
+        return ReviewConverter.toReviewPreviewListDTO(result);
+    }
 }

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryServiceImpl.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryServiceImpl.java
@@ -76,7 +76,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     public ReviewResDTO.ReviewPreViewListDTO getMyReviews(Long userId, Integer page) {
         Member member = memberRepository.findMemberById(userId);
 
-        PageRequest pageRequest = PageRequest.of(page, 5);
+        PageRequest pageRequest = PageRequest.of(page, 10);
         Page<Review> result = reviewRepository.findAllByMember(member, pageRequest);
 
         return ReviewConverter.toReviewPreviewListDTO(result);

--- a/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryServiceImpl.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/review/service/ReviewQueryServiceImpl.java
@@ -29,7 +29,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     private final StoreRepository storeRepository;
 
     @Override
-    public List<ReviewResDTO.GetMyDTO> getMyReviews(Long userId, String storeName, Integer ratingGroup) {
+    public List<ReviewResDTO.GetMyDTO> getReviewsByDetailFilter(Long userId, String storeName, Integer ratingGroup) {
         QReview review = QReview.review;
         BooleanBuilder builder = new BooleanBuilder();
 

--- a/umc9th/src/main/java/com/example/umc9th/domain/store/repository/StoreRepository.java
+++ b/umc9th/src/main/java/com/example/umc9th/domain/store/repository/StoreRepository.java
@@ -3,5 +3,8 @@ package com.example.umc9th.domain.store.repository;
 import com.example.umc9th.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface StoreRepository extends JpaRepository<Store, Long> {
+    Optional<Store> findByName(String name);
 }


### PR DESCRIPTION
# 🚀 UMC 9기 9주차 미션 개발 일지

---

## 1. 미션 목표 (Mission Goals)

- 4가지 API로 구현하기

> 1. 내가 작성한 리뷰 목록 조회 API: `/reviews/my`
> 2. 특정 가게의 미션 목록 조회 API: `/store/{storeId}/mission`
> 3. 내가 진행 중인 미션 목록 조회 API: `/mission/ongoing`
> 4. 진행 중인 미션 진행 완료로 바꾸기 API: `/mission/{missionId}/complete`


---

## 2. 개발 과정 및 학습 내용 (Development Process & Learnings)

### ❗️변경사항
1. API path 변경
- 가게명, 별점으로 리뷰 조회하는 API: `/reviews/detail`로 변경

2. DTO명 변경
- AddDTO -> PreviewDTO로 변경

### 1️⃣ 내가 작성한 리뷰 목록 조회 API
> [GET] `/reviews/my`

- 사용자가 작성한 리뷰 목록 조회
- 페이지네이션으로 제공

#### 👩🏻‍💻 Swagger API 테스트
<img width="1390" height="517" alt="image" src="https://github.com/user-attachments/assets/eab6f2b3-9f11-4108-b641-0fff1dff324b" />


### 2️⃣ 특정 가게의 미션 목록 조회 API
> GET `/store/{storeId}/mission`

- 해당 가게에 등록된 미션 목록 조회
- 페이지네이션으로 제공

#### 👩🏻‍💻 Swagger API 테스트
<img width="1400" height="518" alt="image" src="https://github.com/user-attachments/assets/21e67eae-daeb-488c-bdd0-c26c3af0a50c" />


### 3️⃣ 내가 진행 중인 미션 목록 조회 API
> GET `/mission/ongoing`

- 사용자가 현재 참여 중인 미션 목록을 조회
- 상태는 ONGOING만 조회되며, 페이지네이션이 적용됩니다.

#### 👩🏻‍💻 Swagger API 테스트
<img width="1393" height="516" alt="image" src="https://github.com/user-attachments/assets/e6ef8183-c099-4cbb-aff2-6110db78c8c5" />


### 4️⃣ 진행 중인 미션 완료 처리 API
> PATCH `/mission/{missionId}/complete`

- 사용자가 참여 중인 미션의 상태를 완료(COMPLETED)로 변경함.
- 완료 시 completedAt 날짜도 함께 기록됨.
- 실제로는 Participation 엔티티의 status를 변경하여 비활성화 처리
- 상태 변경 후의 미션 상태 반환

#### 👩🏻‍💻 Swagger API 테스트
<img width="1393" height="485" alt="image" src="https://github.com/user-attachments/assets/872303ed-55c7-487d-95d5-6b1f04674b84" />

---

## 3. 과제 제출 사진

